### PR TITLE
Better handling for unknown encoding

### DIFF
--- a/catz/app.py
+++ b/catz/app.py
@@ -3,7 +3,7 @@ import click
 from click_default_group import DefaultGroup
 
 
-from .commands import (
+from commands import (
     get_content,
     list_lexers,
     list_themes,

--- a/catz/commands/command_helpers.py
+++ b/catz/commands/command_helpers.py
@@ -40,7 +40,7 @@ def get_content_from_file(file):
 
         resolved_path = os.path.expanduser(file) if file.startswith('~') else Path(file).resolve()
 
-        with open(resolved_path, encoding='utf8') as file:
+        with open(resolved_path, encoding='latin-1', errors='backslashreplace') as file:
             data = file.read()
             filename = file.name
 
@@ -48,6 +48,9 @@ def get_content_from_file(file):
 
     except FileNotFoundError:
         raise click.ClickException(f'FileNotFound: {file}')
+
+    except UnicodeEncodeError as e:
+        raise click.ClickException(f'An error occured while encoding the file: {e}')
 
 
 def get_lexer_from_mimetype(mimetype):


### PR DESCRIPTION
Catz currently assumes UTF-8 and will explode if a file has any other encoding forcing the use of `-p`.

This pr implements the following for `open`:

http://python-notes.curiousefficiency.org/en/latest/python3/text_file_processing.html#files-in-an-ascii-compatible-encoding-best-effort-is-acceptable

Fixes #2 