### PR TITLE
use the ignore error handler

### DIFF
--- a/catz/commands/command_helpers.py
+++ b/catz/commands/command_helpers.py
@@ -40,7 +40,7 @@ def get_content_from_file(file):
 
         resolved_path = os.path.expanduser(file) if file.startswith('~') else Path(file).resolve()
 
-        with open(resolved_path, encoding='latin-1', errors='backslashreplace') as file:
+        with open(resolved_path, encoding='utf-8', errors='ignore') as file:
             data = file.read()
             filename = file.name
 
@@ -50,7 +50,7 @@ def get_content_from_file(file):
         raise click.ClickException(f'FileNotFound: {file}')
 
     except UnicodeEncodeError as e:
-        raise click.ClickException(f'An error occured while encoding the file: {e}')
+        raise click.ClickException(f'Could not handle file encoding: {e}')
 
 
 def get_lexer_from_mimetype(mimetype):


### PR DESCRIPTION
Follow on from #3 . Use the `ignore` error handler with open as it should just leave the unknown character out of the unicode result.

See https://docs.python.org/3/howto/unicode.html#the-string-type